### PR TITLE
Changed modulemap file and added a "shim" include file to not require…

### DIFF
--- a/shim.h
+++ b/shim.h
@@ -1,5 +1,5 @@
 //
-//  CommonCrypto Module Map
+//  CommonCrypto shim include file
 //
 // 	Licensed under the Apache License, Version 2.0 (the "License");
 // 	you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 // 	limitations under the License.
 //
 
-module CommonCrypto [system] {
-    header "shim.h"
-    export *
-}
+#include <CommonCrypto/CommonCrypto.h>
+#include <CommonCrypto/CommonRandom.h>
+


### PR DESCRIPTION
The current version of CommonCrypto requires that one install the XCode command line tools in order to add the include files and libraries into directories under /usr on OSX.

Instead with new support in the Swift Package Manager (SPM) this PR enables the building of the library using the includes and shared libraries where they are under the SDK inside the XCode installation.

I tested by doing the following on OSX:
1. Cloned IBM-Swift/BlueCryptor
2. Executed swift build --fetch in the BlueCryptor directory
3. Did a rm -rf Packages/CommonCrypto-0.1.2/*
4. Copied my version of CommonCryto into the Packages/CommonCrypto-0.1.2 directory
5. Executed swift build
6. Executed swift test

All test ran successfully.
